### PR TITLE
[staging] FIRE-33613

### DIFF
--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -2145,36 +2145,19 @@ LLVector3d LLAgentCamera::calcCameraPositionTargetGlobal(BOOL *hit_limit)
     }
 // [/RLVa:KB]
 
-
 #ifdef OPENSIM // humbletim:FIRE-33613: Camera cannot be located at negative Z
-
-// local shadow so we can tune the llmax comprehension below
-F32 F_ALMOST_ZERO = ::F_ALMOST_ZERO;
-
-//#include "llviewernetwork.h" // For LLGridManager
-//if (!LLGridManager::getInstance()->isInSecondLife()) {
-  static LLCachedControl<F32> htxUseMinSimHeight{ gSavedSettings, "htxUseMinSimHeight", 0.0f,
-     "0.0 == stock behavior\n"
-     "1.0 (> 0.0) == apply SimulationFeatures.MinSimHeight (if advertised)\n"
-     "< 0.0f == use this value 'as' MinSimHeight for testing\n"
-  };
-
-  if (htxUseMinSimHeight == 0.0f) {
-    ; // stock behavior
-  } else if (htxUseMinSimHeight < 0.0f) {
-    // coerce floor to specified value
-    F_ALMOST_ZERO += htxUseMinSimHeight;
-   } else if (auto regionp = LLWorld::getInstance()->getRegionFromPosGlobal(camera_position_global)) {
-      LLSD info;
-      regionp->getSimulatorFeatures(info);
-      if (info.has("OpenSimExtras")) {
-        auto const& extras { info["OpenSimExtras"] };
-        F_ALMOST_ZERO += extras["MinSimHeight"].asReal(); // += -100.0
-      }
+    // local variable shadow of the global constant
+    F32 F_ALMOST_ZERO = ::F_ALMOST_ZERO;
+    if (auto regionp = LLWorld::getInstance()->getRegionFromPosGlobal(camera_position_global)) {
+      F_ALMOST_ZERO += regionp->getMinSimHeight();
+//      LLSD info;
+//      regionp->getSimulatorFeatures(info);
+//      if (info.has("OpenSimExtras")) {
+//        auto const& extras { info["OpenSimExtras"] };
+//        F_ALMOST_ZERO += extras["MinSimHeight"].asReal(); // += -100.0
+//      }
     }
-//}
 #endif
-
     // Don't let camera go underground
     F32 camera_min_off_ground = getCameraMinOffGround();
     camera_land_height = LLWorld::getInstance()->resolveLandHeightGlobal(camera_position_global);

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -2146,16 +2146,10 @@ LLVector3d LLAgentCamera::calcCameraPositionTargetGlobal(BOOL *hit_limit)
 // [/RLVa:KB]
 
 #ifdef OPENSIM // humbletim:FIRE-33613: Camera cannot be located at negative Z
-    // local variable shadow of the global constant
+    // local variable shadow of the ground plane constant (used in llmax below)
     F32 F_ALMOST_ZERO = ::F_ALMOST_ZERO;
     if (auto regionp = LLWorld::getInstance()->getRegionFromPosGlobal(camera_position_global)) {
       F_ALMOST_ZERO += regionp->getMinSimHeight();
-//      LLSD info;
-//      regionp->getSimulatorFeatures(info);
-//      if (info.has("OpenSimExtras")) {
-//        auto const& extras { info["OpenSimExtras"] };
-//        F_ALMOST_ZERO += extras["MinSimHeight"].asReal(); // += -100.0
-//      }
     }
 #endif
     // Don't let camera go underground

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -2636,9 +2636,7 @@ void LLViewerRegion::setSimulatorFeatures(const LLSD& sim_features)
 
 // <FS:humbletim> FIRE-33613: camera Z < 0 for OpenSim
 #ifdef OPENSIM
-    if (mSimulatorFeatures.has("OpenSimExtras") && mSimulatorFeatures["OpenSimExtras"].has("MinSimHeight")) {
-        mMinSimHeight = mSimulatorFeatures["OpenSimExtras"]["MinSimHeight"].asReal();
-    }
+    mMinSimHeight = !mSimulatorFeatures.has("OpenSimExtras") ? 0.0f : mSimulatorFeatures["OpenSimExtras"]["MinSimHeight"].asReal();
 #endif // OPENSIM
 // </FS:humbletim>
 }

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -675,7 +675,8 @@ LLViewerRegion::LLViewerRegion(const U64 &handle,
 // </FS:Beq>
     // <FS:CR> Aurora Sim
     mWidth(region_width_meters),
-    mWidthScaleFactor(region_width_meters / REGION_WIDTH_METERS) // <FS:Ansariel> FIRE-19563: Scaling for OpenSim VarRegions
+    mWidthScaleFactor(region_width_meters / REGION_WIDTH_METERS), // <FS:Ansariel> FIRE-19563: Scaling for OpenSim VarRegions
+    mMinSimHeight(0.f) // <FS:humbletim> FIRE-33613: camera Z < 0 for OpenSim
 {
     // Moved this up... -> mWidth = region_width_meters;
 // </FS:CR>
@@ -2632,6 +2633,14 @@ void LLViewerRegion::setSimulatorFeatures(const LLSD& sim_features)
     mMaxTEs   = LLAvatarAppearanceDefines::ETextureIndex::TEX_NUM_INDICES;
 #endif // OPENSIM
 // </FS:Beq>
+
+// <FS:humbletim> FIRE-33613: camera Z < 0 for OpenSim
+#ifdef OPENSIM
+    if (mSimulatorFeatures.has("OpenSimExtras") && mSimulatorFeatures["OpenSimExtras"].has("MinSimHeight")) {
+        mMinSimHeight = mSimulatorFeatures["OpenSimExtras"]["MinSimHeight"].asReal();
+    }
+#endif // OPENSIM
+// </FS:humbletim>
 }
 
 //this is called when the parent is not cacheable.

--- a/indra/newview/llviewerregion.h
+++ b/indra/newview/llviewerregion.h
@@ -249,6 +249,7 @@ public:
 
     F32 getWidth() const                        { return mWidth; }
     F32 getWidthScaleFactor() const             { return mWidthScaleFactor; } // <FS:Ansariel> FIRE-19563: Scaling for OpenSim VarRegions
+    F32 getMinSimHeight() const { return mMinSimHeight; } // <FS:humbletim/> FIRE-33613: camera Z < 0 for OpenSim
 
     // regions are expensive to release, this function gradually releases cache from memory
     static void idleCleanup(F32 max_update_time);
@@ -548,7 +549,8 @@ public:
     S32         mLastUpdate; //last time called idleUpdate()
     F32         mWidthScaleFactor; // <FS:Ansariel> FIRE-19563: Scaling for OpenSim VarRegions
     S32         mMaxBakes; // <FS:Beq/> store max bakes on the region
-    S32         mMaxTEs; // <FS:Beq/> store max bakes on the region
+    S32         mMaxTEs; // <FS:Beq/> store max texture entries on the region
+    F32         mMinSimHeight; // <FS:humbletim/> FIRE-33613: OpenSim camera Z < 0
     // simulator name
     std::string mName;
     std::string mZoning;


### PR DESCRIPTION
note: migrated into `FirestormViewer/phoenix-firestorm#27`

> This PR addresses a regression introduced in recent Firestorm releases (7.1.3 and likely earlier) that prevents the camera from being positioned below Z=0 in OpenSim regions. This issue disrupts the ability of users to view avatars and objects situated at negative Z, hindering interaction with underwater builds and other scenarios. 
> 
> **Changes:**
> 
> - **Introduced `LLViewerRegion::mMinSimHeight` and `LLViewerRegion::getMinSimHeight()`** to track the minimum simulation height advertised by OpenSim regions. 
> - **Refactored the camera position calculation** in `llagentcamera.cpp` to respect `mMinSimHeight` when applicable, effectively removing the artificial Z=0 floor for OpenSim regions.
> 
> This solution leverages existing OpenSim infrastructure by using the `OpenSimExtras.MinSimHeight` value advertised in Simulation Features. If this value is not present, the default behavior is preserved, ensuring compatibility with Second Life.
> 
> **Note:** This change is specific to OpenSim and does not affect Second Life behavior. 
> 
> -  This PR leverages existing OpenSim infrastructure, promoting interoperability.
> -  The changes are straightforward and do not introduce new dependencies.
> 
> **See also:**
> 
> - [FIRE-33613: [OpenSim] [PBR] Camera cannot be located at negative Z](https://jira.firestormviewer.org/browse/FIRE-33613) Jira bug report
> - [metaverse-crossroads/hypergrid-junction#2](https://github.com/metaverse-crossroads/hypergrid-junction/issues/2) for detailed discussion and investigation. 
> 